### PR TITLE
add load_column_parallel_weight to recorded_loader_keys

### DIFF
--- a/flash_rl/vllm_patch.py
+++ b/flash_rl/vllm_patch.py
@@ -42,6 +42,7 @@ recorded_loader_keys = [
     'weight_loader',
     'load_qkv_weight',
     'load_row_parallel_weight',
+    'load_column_parallel_weight',
     'load_merged_column_weight',
     'output_dim',
     'input_dim',


### PR DESCRIPTION
add load_column_parallel_weight to recorded_loader_keys to solve the problem AttributeError: 'Parameter' object has no attribute 'load_column_parallel_weight'